### PR TITLE
adjust for #3, keyboard press & hold, fade in/out

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,23 @@ Reveal.initialize({
 			// toggle spotlight by holding down the mouse key
 			toggleSpotlightOnMouseDown: true,
 
+			// the keyCode pressed and held to turn on spotlight, disabled when set to false
+			spotlightOnKeyPressAndHold: false,
+
 			// choose the cursor when spotlight is on. Maybe "crosshair"?
+			spotlightCursor: 'none',
+
+			// choose the cursor when spotlight is off and in presentation mode. Maybe "default"?
 			presentingCursor: 'none', 
 
-			// true: cursor is always "none" except when spotlight is on. 
-			presentingCursorOnlyVisibleWhenSpotlightVisible: true,
+			// true: initially in presentation mode, will be ture if this is not set and toggleSpotlightOnMouseDown is true
+			initialPresentationMode: true,
+
+			// true: disable selecting in presentation mode
+			disablingUserSelect: true,
+
+			// set to a number as transition duration to enable fade in and out
+			fadeInAndOut: false,
 
 			// enable pointer mode
 			useAsPointer: true,

--- a/spotlight.js
+++ b/spotlight.js
@@ -3,8 +3,12 @@ var RevealSpotlight = window.RevealSpotlight || (function () {
   //configs
   var spotlightSize;
   var toggleOnMouseDown;
+  var spotlightOnKeyPressAndHold;
   var presentingCursor;
-  var presentingCursorOnlyVisibleWhenSpotlightVisible;
+  var spotlightCursor;
+  var initialPresentationMode;
+  var disablingUserSelect;
+  var fadeInAndOut;
   var style;
   var lockPointerInsideCanvas;
   var getMousePos;
@@ -12,6 +16,8 @@ var RevealSpotlight = window.RevealSpotlight || (function () {
   var drawBoard;
   var isSpotlightOn = true;
   var isCursorOn = true;
+
+  var lastMouseMoveEvent;
 
   function onRevealJsReady(event) {
     configure();
@@ -23,9 +29,13 @@ var RevealSpotlight = window.RevealSpotlight || (function () {
 
     if (toggleOnMouseDown) {
       addMouseToggleSpotlightListener();
-      setCursor(false);
     }
 
+    if (spotlightOnKeyPressAndHold) {
+      addKeyPressAndHoldSpotlightListener(spotlightOnKeyPressAndHold);
+    }
+
+    setCursor(!initialPresentationMode);
     setSpotlight(false);
   }
 
@@ -33,6 +43,7 @@ var RevealSpotlight = window.RevealSpotlight || (function () {
     var config = Reveal.getConfig().spotlight || {};
     spotlightSize = config.size || 60;
     presentingCursor = config.presentingCursor || "none";
+    spotlightCursor = config.spotlightCursor || "none";
     var useAsPointer = config.useAsPointer || false;
     var pointerColor = config.pointerColor || 'red';
     lockPointerInsideCanvas = config.lockPointerInsideCanvas || false;
@@ -63,11 +74,28 @@ var RevealSpotlight = window.RevealSpotlight || (function () {
       toggleOnMouseDown = true;
     }
 
-    if (config.hasOwnProperty(
-        "presentingCursorOnlyVisibleWhenSpotlightVisible")) {
-      presentingCursorOnlyVisibleWhenSpotlightVisible = config.presentingCursorOnlyVisibleWhenSpotlightVisible;
+    if (config.hasOwnProperty("initialPresentationMode")) {
+      initialPresentationMode = config.initialPresentationMode;
     } else {
-      presentingCursorOnlyVisibleWhenSpotlightVisible = true;
+      initialPresentationMode = toggleOnMouseDown;
+    }
+
+    if (config.hasOwnProperty("spotlightOnKeyPressAndHold")) {
+      spotlightOnKeyPressAndHold = config.spotlightOnKeyPressAndHold;
+    } else {
+      spotlightOnKeyPressAndHold = false;
+    }
+
+    if (config.hasOwnProperty("disablingUserSelect")) {
+      disablingUserSelect = config.disablingUserSelect;
+    } else {
+      disablingUserSelect = true;
+    }
+
+    if (config.hasOwnProperty("fadeInAndOut")) {
+      fadeInAndOut = config.fadeInAndOut;
+    } else {
+      fadeInAndOut = false;
     }
   }
 
@@ -75,6 +103,9 @@ var RevealSpotlight = window.RevealSpotlight || (function () {
     var container = document.createElement('div');
     container.id = "spotlight";
     container.style.cssText = "position:absolute;top:0;left:0;bottom:0;right:0;z-index:99;";
+    if (fadeInAndOut) {
+      container.style.cssText += "transition: " + fadeInAndOut + "ms opacity;";
+    }
 
     var canvas = document.createElement('canvas');
     var context = canvas.getContext("2d");
@@ -84,7 +115,8 @@ var RevealSpotlight = window.RevealSpotlight || (function () {
 
     container.appendChild(canvas);
     document.body.appendChild(container);
-    container.style.display = "none";
+    container.style.opacity = 0;
+    container.style['pointer-events'] = 'none';
     return {
       container,
       canvas,
@@ -101,53 +133,65 @@ var RevealSpotlight = window.RevealSpotlight || (function () {
   }
 
   function addMouseMoveListener() {
-    drawBoard.canvas.addEventListener('mousemove', function (e) {
+    document.body.addEventListener('mousemove', function (e) {
       if(isSpotlightOn) {
         showSpotlight(e);
       }
+      lastMouseMoveEvent = e;
     }, false);
   }
 
   function addMouseToggleSpotlightListener() {
 
     window.addEventListener("mousedown", function (e) {
-      if (lockPointerInsideCanvas && document.pointerLockElement != drawBoard.canvas) {
-        drawBoard.canvas.requestPointerLock();
-      }
-
       if (!isCursorOn) {
-        setSpotlight(true);
-        if (presentingCursorOnlyVisibleWhenSpotlightVisible) {
-          document.body.style.cursor = presentingCursor;
-        }
-
-        showSpotlight(e);
+        setSpotlight(true, e);
       }
     }, false);
 
     window.addEventListener("mouseup", function (e) {
       if (!isCursorOn) {
+        setSpotlight(false, e);
+      }
+    }, false);
+  }
+
+  function addKeyPressAndHoldSpotlightListener(keyCode) {
+
+    window.addEventListener("keydown", function (e) {
+      if (!isCursorOn && !isSpotlightOn && e.keyCode === keyCode) {
+        setSpotlight(true, lastMouseMoveEvent);
+      }
+    }, false);
+
+    window.addEventListener("keyup", function (e) {
+      if (!isCursorOn && e.keyCode === keyCode) {
         setSpotlight(false);
-        if (presentingCursorOnlyVisibleWhenSpotlightVisible) {
-          document.body.style.cursor = "none";
-        }
       }
     }, false);
   }
 
   function toggleSpotlight() {
-    setSpotlight(!isSpotlightOn);
+    setSpotlight(!isSpotlightOn, lastMouseMoveEvent);
   }
 
-  function setSpotlight(isOn) {
+  function setSpotlight(isOn, mouseEvt) {
     isSpotlightOn = isOn;
     var container = drawBoard.container;
     if (isOn) {
-      container.style.display = "block";
+      if (lockPointerInsideCanvas && document.pointerLockElement != drawBoard.canvas) {
+        drawBoard.canvas.requestPointerLock();
+      }
+      container.style.opacity = 1;
+      container.style['pointer-events'] = null;
+      document.body.style.cursor = spotlightCursor;
+      if (mouseEvt) {
+        showSpotlight(mouseEvt);
+      }
     } else {
-      container.style.display = "none";
-      drawBoard.context.clearRect(0, 0, drawBoard.canvas.width,
-          drawBoard.canvas.height);
+      container.style.opacity = 0;
+      container.style['pointer-events'] = 'none';
+      document.body.style.cursor = presentingCursor;
     }
   }
 
@@ -158,17 +202,15 @@ var RevealSpotlight = window.RevealSpotlight || (function () {
   function setCursor(isOn) {
     isCursorOn = isOn;
     if (isOn) {
-      document.body.style.userSelect = "auto";
-      document.body.style.cursor = "default";
-    } else {
-
-      document.body.style.userSelect = "none";
-
-      if (presentingCursorOnlyVisibleWhenSpotlightVisible) {
-        document.body.style.cursor = "none";
-      } else {
-        document.body.style.cursor = presentingCursor;
+      if (disablingUserSelect) {
+        document.body.style.userSelect = null;
       }
+      document.body.style.cursor = null;
+    } else {
+      if (disablingUserSelect) {
+        document.body.style.userSelect = "none";
+      }
+      document.body.style.cursor = presentingCursor;
     }
   }
 


### PR DESCRIPTION
1. rename option presentingCursor to spotlightCursor
2. remove option presentingCursorOnlyVisibleWhenSpotlightVisible
3. add option presentingCursor to set cursor when presentaion mode
enabled but not in spotlight mode
4. add option spotlightOnKeyPressAndHold for keyboard and touchpad
usage, press and hold to turn on spotlight, release to turn off
5. add option initialPresentationMode to force presentation mode
initially when toggleSpotlightOnMouseDown is false
6. add option disablingUserSelect to choose if it should allow selecting
7. add option fadeInAndOut to enable fade in/out transition

I am not sure if my understanding of presentation mode is correct...